### PR TITLE
Fix QOpenGL context API for Qt6

### DIFF
--- a/src/RenderingSystem.cpp
+++ b/src/RenderingSystem.cpp
@@ -3,6 +3,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <QDebug>
 #include <QOpenGLContext>
+#include <QOpenGLVersionFunctionsFactory>
 
 namespace RenderingSystem
 {
@@ -40,7 +41,7 @@ namespace RenderingSystem
             qWarning() << "[RenderingSystem] initialize called without current context";
             return;
         }
-        g_gl.reset(QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_3_3_Core>());
+        g_gl.reset(QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_3_3_Core>(QOpenGLContext::currentContext()));
         if (!g_gl)
         {
             qWarning() << "[RenderingSystem] failed to obtain OpenGL functions";


### PR DESCRIPTION
## Summary
- include `QOpenGLVersionFunctionsFactory`
- update OpenGL initialization to use `QOpenGLVersionFunctionsFactory` since `versionFunctions` was removed in Qt6

## Testing
- `cmake -S . -B build2` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684e530cb7748329b84d7721a77d0dd1