### PR TITLE
Fix OpenGL shader deletion on reinitialization

### DIFF
--- a/src/RenderingSystem.cpp
+++ b/src/RenderingSystem.cpp
@@ -36,6 +36,11 @@ namespace RenderingSystem
 
     void initialize()
     {
+        // Ensure any previously created resources are released while the
+        // previous OpenGL function pointer table is still valid.  This avoids
+        // dangling pointers in Shader destructors when reinitializing.
+        shutdown(nullptr);
+
         if (!QOpenGLContext::currentContext())
         {
             qWarning() << "[RenderingSystem] initialize called without current context";


### PR DESCRIPTION
## Summary
- prevent dangling function pointer usage by cleaning up resources before recreating OpenGL function table

## Testing
- `cmake -S . -B build_new` *(fails: Could not find package configuration file provided by "Qt6")*

------
https://chatgpt.com/codex/tasks/task_e_684e54c32de8832985b16e89793e2b1e