### PR TITLE
Fix OpenGL resource teardown order

### DIFF
--- a/src/RenderingSystem.cpp
+++ b/src/RenderingSystem.cpp
@@ -36,6 +36,11 @@ namespace RenderingSystem
 
     void initialize()
     {
+        // Ensure any previously created resources are released while the
+        // previous OpenGL function pointer table is still valid.  This avoids
+        // dangling pointers in Shader destructors when reinitializing.
+        shutdown(nullptr);
+
         if (!QOpenGLContext::currentContext())
         {
             qWarning() << "[RenderingSystem] initialize called without current context";

--- a/src/ViewportWidget.cpp
+++ b/src/ViewportWidget.cpp
@@ -62,9 +62,14 @@ ViewportWidget::~ViewportWidget()
 {
     if (isValid()) {
         makeCurrent();
-        RenderingSystem::shutdown(m_scene);
+        // Destroy our own OpenGL resources while the function table is still
+        // valid.  RenderingSystem::shutdown() resets its QOpenGLFunctions
+        // object, which would otherwise invalidate these pointers before the
+        // Shader and buffer deletions occur.
+        m_outlineShader.reset();
         if (m_outlineVAO != 0) glDeleteVertexArrays(1, &m_outlineVAO);
         if (m_outlineVBO != 0) glDeleteBuffers(1, &m_outlineVBO);
+        RenderingSystem::shutdown(m_scene);
     }
 }
 


### PR DESCRIPTION
## Summary
- release ViewportWidget's shader and buffers before shutting down the global RenderingSystem
- clean up global rendering resources prior to function table reset

## Testing
- `cmake -S . -B build_new` *(fails: Could not find package configuration file provided by "Qt6")*


------
https://chatgpt.com/codex/tasks/task_e_684e54c32de8832985b16e89793e2b1e