### PR TITLE
Fix duplicate cleanupGL declaration

### DIFF
--- a/include/ViewportWidget.hpp
+++ b/include/ViewportWidget.hpp
@@ -27,9 +27,6 @@ public:
     ViewportWidget(Scene* scene, entt::entity cameraEntity, QWidget* parent = nullptr);
     ~ViewportWidget();
 
-private slots:
-    void cleanupGL();
-
     Camera& getCamera();
 
 private slots:


### PR DESCRIPTION
## Summary
- cleanup duplicate `cleanupGL()` declaration in `ViewportWidget.hpp`
- expose `getCamera()` as a public method again

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e63171e008329b3f42b7d8ab288b6