### PR TITLE
Fix crash when closing ViewportWidget

### DIFF
--- a/src/ViewportWidget.cpp
+++ b/src/ViewportWidget.cpp
@@ -64,7 +64,10 @@ ViewportWidget::ViewportWidget(Scene* scene, entt::entity cameraEntity, QWidget*
 
 }
 
-ViewportWidget::~ViewportWidget() = default;
+ViewportWidget::~ViewportWidget()
+{
+    cleanupGL();
+}
 
 void ViewportWidget::cleanupGL()
 {
@@ -100,7 +103,7 @@ void ViewportWidget::initializeGL()
     // Ensure resources are released before the context goes away
     if (QOpenGLContext* ctx = context()) {
         connect(ctx, &QOpenGLContext::aboutToBeDestroyed,
-                this, &ViewportWidget::cleanupGL);
+                this, &ViewportWidget::cleanupGL, Qt::DirectConnection);
     }
 
     // Setup a debug logger if the context supports it


### PR DESCRIPTION
## Summary
- clean up GL resources in `ViewportWidget` destructor
- ensure cleanup runs before context is destroyed using `Qt::DirectConnection`

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684e645ab37083298a910fa827dca0ba