### PR TITLE
Fix double cleanup in ViewportWidget

### DIFF
--- a/include/ViewportWidget.hpp
+++ b/include/ViewportWidget.hpp
@@ -58,4 +58,7 @@ private:
 
     // Emits detailed OpenGL debug output when a debug context is available
     std::unique_ptr<QOpenGLDebugLogger> m_debugLogger;
+
+    // Guard to ensure cleanupGL() is only executed once
+    bool m_cleanedUp = false;
 };


### PR DESCRIPTION
## Summary
- track whether GL cleanup has happened
- disconnect cleanup signal before base destructors run

## Testing
- `cmake -S . -B build -G Ninja` *(fails: could not find Qt6)*
- `cmake --build build` *(fails: build.ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e660a6b6483298a49e8b52814c190