### PR TITLE
Fix runtime crash on closing

### DIFF
--- a/src/ViewportWidget.cpp
+++ b/src/ViewportWidget.cpp
@@ -98,7 +98,8 @@ void ViewportWidget::cleanupGL()
     qDebug() << "[ViewportWidget] Making context current for cleanup.";
 
 
-    if (!context()->makeCurrent(context()->surface())) {
+    makeCurrent();
+    if (!context() || !context()->isValid()) {
         qWarning() << "[ViewportWidget] Failed to make context current for cleanup";
         return;
     }


### PR DESCRIPTION
## Summary
- handle cleanup using `QOpenGLWidget::makeCurrent()`

## Testing
- `ninja -C build` *(fails: build.ninja uses Windows paths)*

------
https://chatgpt.com/codex/tasks/task_e_684e6e482e008329aabe6df0e08675ec