### PR TITLE
Integrate safe GL teardown

### DIFF
--- a/include/ViewportWidget.hpp
+++ b/include/ViewportWidget.hpp
@@ -18,6 +18,7 @@ class QTimer;
 class QMouseEvent;
 class QWheelEvent;
 class QKeyEvent;
+class QCloseEvent;
 
 
 class ViewportWidget : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core
@@ -26,7 +27,7 @@ class ViewportWidget : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core
 
 public:
     ViewportWidget(Scene* scene, entt::entity cameraEntity, QWidget* parent = nullptr);
-    ~ViewportWidget();
+    ~ViewportWidget() override;
 
     Camera& getCamera();
 
@@ -42,6 +43,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
 
 private:
     Scene* m_scene;
@@ -62,7 +64,4 @@ private:
 
     // Guard to ensure cleanupGL() is only executed once
     bool m_cleanedUp = false;
-
-    // Connection handle for context destruction
-    QMetaObject::Connection m_ctxDestroyConnection;
 };


### PR DESCRIPTION
## Summary
- add QCloseEvent handling in ViewportWidget
- ensure GL resources are released from closeEvent
- simplify destructor and remove context destruction logic

## Testing
- `ctest -q` *(fails: No tests were found)*
- `cmake --build build -j 4` *(fails: cache directory mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684e7647db4c83299a9cdc3de38d5fb9