### PR TITLE
Integrate safe GL teardown

### DIFF
--- a/include/MainWindow.hpp
+++ b/include/MainWindow.hpp
@@ -36,9 +36,10 @@ private:
     // The MainWindow now owns the single, shared scene.
     std::unique_ptr<Scene> m_scene;
 
-    // We no longer need pointers to the individual viewports here,
-    // as the dock manager handles their lifecycle. We will create them
-    // as local variables in the constructor.
+    // We keep explicit pointers to the viewports so we can control
+    // their destruction order relative to the OpenGL context.
+    ViewportWidget* m_viewport1 = nullptr;
+    ViewportWidget* m_viewport2 = nullptr;
 
 private slots:
     void onLoadRobotClicked();

--- a/include/ViewportWidget.hpp
+++ b/include/ViewportWidget.hpp
@@ -18,6 +18,7 @@ class QTimer;
 class QMouseEvent;
 class QWheelEvent;
 class QKeyEvent;
+class QCloseEvent;
 
 
 class ViewportWidget : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core
@@ -26,7 +27,7 @@ class ViewportWidget : public QOpenGLWidget, public QOpenGLFunctions_3_3_Core
 
 public:
     ViewportWidget(Scene* scene, entt::entity cameraEntity, QWidget* parent = nullptr);
-    ~ViewportWidget();
+    ~ViewportWidget() override;
 
     Camera& getCamera();
 
@@ -42,6 +43,7 @@ protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     void wheelEvent(QWheelEvent* event) override;
     void keyPressEvent(QKeyEvent* event) override;
+    void closeEvent(QCloseEvent* event) override;
 
 private:
     Scene* m_scene;
@@ -62,7 +64,4 @@ private:
 
     // Guard to ensure cleanupGL() is only executed once
     bool m_cleanedUp = false;
-
-    // Connection handle for context destruction
-    QMetaObject::Connection m_ctxDestroyConnection;
 };

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -87,17 +87,17 @@ MainWindow::MainWindow(QWidget* parent)
     this->setCentralWidget(m_centralContainer);
 
     // --- 4. Setup Viewports ---
-    ViewportWidget* viewport1 = new ViewportWidget(m_scene.get(), cameraEntity1, this);
-    viewport1->setMinimumSize(400, 300);
+    m_viewport1 = new ViewportWidget(m_scene.get(), cameraEntity1, this);
+    m_viewport1->setMinimumSize(400, 300);
     ads::CDockWidget* viewportDock1 = new ads::CDockWidget("3D Viewport 1 (Perspective)");
-    viewportDock1->setWidget(viewport1);
+    viewportDock1->setWidget(m_viewport1);
     viewportDock1->setFeature(ads::CDockWidget::DockWidgetClosable, false);
     m_dockManager->addDockWidget(ads::CenterDockWidgetArea, viewportDock1);
 
-    ViewportWidget* viewport2 = new ViewportWidget(m_scene.get(), cameraEntity2, this);
-    viewport2->setMinimumSize(400, 300);
+    m_viewport2 = new ViewportWidget(m_scene.get(), cameraEntity2, this);
+    m_viewport2->setMinimumSize(400, 300);
     ads::CDockWidget* viewportDock2 = new ads::CDockWidget("3D Viewport 2 (Top Down)");
-    viewportDock2->setWidget(viewport2);
+    viewportDock2->setWidget(m_viewport2);
     viewportDock2->setFeature(ads::CDockWidget::DockWidgetClosable, false);
     m_dockManager->addDockWidget(ads::RightDockWidgetArea, viewportDock2);
 
@@ -115,25 +115,25 @@ MainWindow::MainWindow(QWidget* parent)
     m_dockManager->addDockWidget(ads::RightDockWidgetArea, propertiesDock);
 
     // --- 6. Setup Signal/Slot connections ---
-    connect(viewportDock1, &ads::CDockWidget::topLevelChanged, this, [viewport1](bool isFloating) {
+    connect(viewportDock1, &ads::CDockWidget::topLevelChanged, this, [this](bool isFloating) {
         Q_UNUSED(isFloating);
-        if (viewport1) {
-            QTimer::singleShot(0, viewport1, [=]() {
-                viewport1->getCamera().setToKnownGoodView();
-                viewport1->update();
-                });
+        if (m_viewport1) {
+            QTimer::singleShot(0, m_viewport1, [=]() {
+                m_viewport1->getCamera().setToKnownGoodView();
+                m_viewport1->update();
+            });
         }
-        });
+    });
 
-    connect(viewportDock2, &ads::CDockWidget::topLevelChanged, this, [viewport2](bool isFloating) {
+    connect(viewportDock2, &ads::CDockWidget::topLevelChanged, this, [this](bool isFloating) {
         Q_UNUSED(isFloating);
-        if (viewport2) {
-            QTimer::singleShot(0, viewport2, [=]() {
-                viewport2->getCamera().setToKnownGoodView();
-                viewport2->update();
-                });
+        if (m_viewport2) {
+            QTimer::singleShot(0, m_viewport2, [=]() {
+                m_viewport2->getCamera().setToKnownGoodView();
+                m_viewport2->update();
+            });
         }
-        });
+    });
 
     connect(m_fixedTopToolbar, &StaticToolbar::loadRobotClicked, this, &MainWindow::onLoadRobotClicked);
 
@@ -151,6 +151,8 @@ MainWindow::MainWindow(QWidget* parent)
 
 MainWindow::~MainWindow()
 {
+    delete m_viewport1;
+    delete m_viewport2;
 }
 
 void MainWindow::onLoadRobotClicked()


### PR DESCRIPTION
## Summary
- add QCloseEvent handling in ViewportWidget
- ensure GL resources are released from closeEvent
- simplify destructor and remove context destruction logic
- explicitly manage ViewportWidget lifetime in MainWindow

## Testing
- `cmake --build build -j 4` *(fails: cache directory mismatch)*
- `ctest -q` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_684e7647db4c83299a9cdc3de38d5fb9