### PR TITLE
Fix entt registry resets and ensure GL cleanup

### DIFF
--- a/src/PreviewViewport.cpp
+++ b/src/PreviewViewport.cpp
@@ -1,5 +1,6 @@
 #include "PreviewViewport.hpp"
 #include "SceneBuilder.hpp"
+#include "Scene.hpp"
 #include "Shader.hpp"
 #include "Mesh.hpp"
 #include "Camera.hpp"
@@ -70,10 +71,8 @@ void PreviewViewport::updateRobot(const RobotDescription& description)
     makeCurrent();
     m_robotDesc = std::make_unique<RobotDescription>(description);
 
-    qDebug() << "[PreviewViewport] Clearing"
-             << m_scene->getRegistry().storage<entt::entity>().size()
-             << "old entities from the scene.";
-    m_scene->getRegistry().clear();
+    qDebug() << "[PreviewViewport] Resetting preview scene";
+    m_scene = std::make_unique<Scene>();
 
     m_cameraEntity = m_scene->getRegistry().create();
     m_scene->getRegistry().emplace<CameraComponent>(m_cameraEntity).camera.forceRecalculateView(glm::vec3(1.5f, 1.5f, 2.0f), glm::vec3(0.0f, 0.5f, 0.0f), 0.0f);


### PR DESCRIPTION
## Summary
- add Scene include to PreviewViewport
- reset the preview viewport scene using a new Scene object instead of clearing the registry

## Testing
- `cmake -S . -B cmake-build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_684f5c590ff08329a73cbbabe81242dd